### PR TITLE
gemspec: Allow newer rails

### DIFF
--- a/jazz_hands.gemspec
+++ b/jazz_hands.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'hirb', '~> 0.7'
   gem.add_runtime_dependency 'pry-coolline', '~> 0.2'
   gem.add_runtime_dependency 'amazing_print', '>= 1.4.0'
-  gem.add_runtime_dependency 'railties', '>= 3.0', '< 7.1'
+  gem.add_runtime_dependency 'railties', '>= 3.0', '< 7.2'
 end


### PR DESCRIPTION
Bumps runtime dependency on railties to allow versions up to 7.1.x via `< 7.2`